### PR TITLE
Usgs/earthquake hazard tool#65

### DIFF
--- a/src/htdocs/css/_ComponentCurvesGraphView.scss
+++ b/src/htdocs/css/_ComponentCurvesGraphView.scss
@@ -1,0 +1,4 @@
+
+.ComponentCurvesGraphView-empty {
+  display: none;
+}

--- a/src/htdocs/css/index.scss
+++ b/src/htdocs/css/index.scss
@@ -14,6 +14,7 @@
 @import '_ApplicationView.scss';
 @import '_AnalysisCollectionView.scss';
 @import '_AnalysisView.scss';
+@import '_ComponentCurvesGraphView.scss';
 @import '_Fullscreen.scss';
 @import '_BasicInputsView.scss';
 @import '_DataExport.scss';

--- a/src/htdocs/js/ApplicationView.js
+++ b/src/htdocs/js/ApplicationView.js
@@ -3,6 +3,7 @@
 var ActionsView = require('ActionsView'),
     BasicInputsView = require('BasicInputsView'),
     Calculator = require('Calculator'),
+    ComponentCurvesGraphView = require('ComponentCurvesGraphView'),
     HazardCurveView = require('HazardCurveGraphView'),
     HazardSpectrumView = require('ResponseSpectrumGraphView'),
     MapView = require('MapView'),
@@ -23,6 +24,8 @@ var ApplicationView = function (params) {
       _basicInputsEl,
       _basicInputsView,
       _calculator,
+      _componentCurveEl,
+      _componentCurveView,
       _curves,
       _dependencyFactory,
       _editions,
@@ -95,6 +98,12 @@ var ApplicationView = function (params) {
       el: _hazardSpectrumEl,
       title: 'Hazard Response Spectrum'
     });
+
+    _componentCurveView = ComponentCurvesGraphView({
+      collection: _curves,
+      el: _componentCurveEl,
+      title: 'Hazard Curve Compoents'
+    });
   };
 
 
@@ -116,12 +125,15 @@ var ApplicationView = function (params) {
         '</section>',
         '<section class="application-hazard-spectrum column one-of-two">',
         '</section>',
+        '<section class="application-hazard-component column one-of-two">',
+        '</section>',
       '</div>'
     ].join('');
 
     _basicInputsEl = el.querySelector('.application-basic-inputs');
     _mapEl = el.querySelector('.application-map');
     _actionsEl = el.querySelector('.application-actions');
+    _componentCurveEl = el.querySelector('.application-hazard-component');
     _hazardCurveEl = el.querySelector('.application-hazard-curve');
     _hazardSpectrumEl = el.querySelector('.application-hazard-spectrum');
   };

--- a/src/htdocs/js/ComponentCurvesGraphView.js
+++ b/src/htdocs/js/ComponentCurvesGraphView.js
@@ -1,0 +1,102 @@
+'use strict';
+
+var Collection = require('mvc/Collection'),
+    SelectedCollectionView = require('mvc/SelectedCollectionView'),
+    Util = require('util/Util'),
+
+    HazardCurveGraphView = require('./HazardCurveGraphView');
+
+
+var _EMPTY_CLASS,
+    _VIEW_CLASS;
+
+// view class name
+_VIEW_CLASS = 'ComponentCurvesGraphView';
+
+// class name added when there aren't curves to plot.
+_EMPTY_CLASS = 'ComponentCurvesGraphView-empty';
+
+
+/**
+ * ComponentCurvesGraphView extends SelectedCollectionView to display
+ * component curves for the currently selected HazardCurve.
+ *
+ * It takes component curves from the currently selected HazardCurve and
+ * displays them using a HazardCurveGraphView.
+ */
+var ComponentCurvesGraphView = function (options) {
+  var _this,
+      _initialize,
+
+      _curves,
+      _curveView;
+
+
+  _this = SelectedCollectionView(options);
+
+  /**
+   * Initialize the ComponentCurvesGraphView.
+   */
+  _initialize = function (/*options*/) {
+    _this.el.classList.add(_VIEW_CLASS);
+    _this.el.classList.add(_EMPTY_CLASS);
+    _this.el.innerHTML = '<div></div>';
+
+    _curves = Collection();
+    _curveView = HazardCurveGraphView({
+      el: _this.el.querySelector('div'),
+      curves: _curves
+    });
+  };
+
+  /**
+   * Destroy collection and wrapped view.
+   */
+  _this.destroy = Util.compose(function () {
+    _curveView.destroy();
+    _curveView = null;
+
+    _curves.destroy();
+    _curves = null;
+  }, _this.destroy);
+
+  /**
+   * Update the title and curves collection with either component curves from
+   * currently selected HazardCurve, or empty array if no components exist.
+   */
+  _this.render = function () {
+    var components,
+        label;
+
+    label = 'Component Curves for ';
+    if (_this.model !== null) {
+      components = _this.model.get('components');
+      label += _this.model.get('label');
+      if (components !== null) {
+        components = components.data();
+      }
+    }
+    components = components || [];
+
+    // manage state class
+    if (components.length === 0) {
+      _this.el.classList.add(_EMPTY_CLASS);
+    } else {
+      _this.el.classList.remove(_EMPTY_CLASS);
+    }
+
+    // update collection
+    _curveView.model.set({
+      title: label
+    }, {silent: true});
+    _curves.reset(components);
+  };
+
+
+  _initialize(options);
+  options = null;
+  return _this;
+};
+
+
+module.exports = ComponentCurvesGraphView;


### PR DESCRIPTION
Fixes usgs/earthquake-hazard-tool#65 .

ComponentCurvesGraphView is only shown when component curves are available, so depends on configuration and use of a dynamic service.