### PR TITLE
Update LoaderView so that user can cancel a calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "hazdev-location-view": "~0.1.0",
     "hazdev-tablist": "~0.1.0",
     "hazdev-template": "~0.2.0",
-    "hazdev-webutils": "~0.1.0",
+    "hazdev-webutils": "~0.1.2",
     "http-rewrite-middleware": "^0.1.6",
     "ini": "^1.3.4",
     "leaflet": "^0.7.7",

--- a/src/htdocs/js/ApplicationView.js
+++ b/src/htdocs/js/ApplicationView.js
@@ -427,16 +427,17 @@ var ApplicationView = function (params) {
   };
 
   _this.queueCalculation = function () {
+    var request;
     if (!_queued) {
       window.setTimeout(function () {
         if (_this.model.get('edition') && _this.model.get('location') &&
             _this.model.get('region') && _this.model.get('vs30')) {
-          _loaderView.show();
-          _calculator.getResult(
+          request = _calculator.getResult(
               _dependencyFactory.getService(_this.model.get('edition')),
               _this.model,
               _loaderView.hide
             );
+          _loaderView.show(request);
         }
         _queued = false;
       }, 0);

--- a/src/htdocs/js/Calculator.js
+++ b/src/htdocs/js/Calculator.js
@@ -59,7 +59,7 @@ var Calculator = function (/*params*/) {
       }
     }
 
-    Xhr.ajax({
+    var request = Xhr.ajax({
       url: url,
       success: function (response) {
         analysis.set({
@@ -71,6 +71,8 @@ var Calculator = function (/*params*/) {
         }
       }
     });
+
+    return request;
   };
 
   return _this;

--- a/src/htdocs/js/LoaderView.js
+++ b/src/htdocs/js/LoaderView.js
@@ -9,6 +9,8 @@ var LoaderView = function() {
   var _this,
       _initialize,
 
+      _cancelButton,
+      _request,
       _showCount,
 
       _isVisible;
@@ -23,7 +25,11 @@ var LoaderView = function() {
     _this.el.innerHTML = '<div class="loader-container">' +
         '<div class="loader"></div>' +
         '<p class="loader-text">Calculating</p>' +
+        '<button class="cancel-request">Cancel Request</button>' +
       '</div>';
+
+    _cancelButton = _this.el.querySelector('.cancel-request');
+    _cancelButton.addEventListener('click', _this.cancel, _this);
   };
 
 
@@ -32,7 +38,11 @@ var LoaderView = function() {
   };
 
 
-  _this.show = function () {
+  _this.show = function (request) {
+    if (request) {
+      _request = request;
+    }
+
     if (_showCount === 0) {
       document.body.appendChild(_this.el);
     }
@@ -52,9 +62,25 @@ var LoaderView = function() {
     }
   };
 
+  _this.cancel = function () {
+    // cancel XHR request
+    if (_request) {
+      _request.abort();
+      _request = null;
+    }
+
+    // close spinner
+    _this.hide();
+  };
+
   _this.destroy = Util.compose(function () {
+
+    _cancelButton.removeEventListener('click', _this.cancel, _this);
+
     _isVisible = null;
 
+    _cancelButton = null;
+    _request = null;
     _showCount = null;
 
     _this = null;


### PR DESCRIPTION
Added a button to the loader that aborts the xhr request, effectively canceling the calculation
- fixes usgs/earthquake-hazard-tool#92
- depends on https://github.com/usgs/hazdev-webutils/pull/67