### PR TITLE
Location input fix

### DIFF
--- a/src/htdocs/js/DependencyFactory.js
+++ b/src/htdocs/js/DependencyFactory.js
@@ -352,6 +352,9 @@ var DependencyFactory = function (params) {
 
     if (editionId) {
       edition = _this.getEdition(editionId);
+      if (!edition) {
+        return [];
+      }
       regions = edition.get('supports').region || [];
 
       regions = regions.map(function (regionId) {

--- a/src/htdocs/js/input/Location.js
+++ b/src/htdocs/js/input/Location.js
@@ -211,6 +211,10 @@ var Location = function (params) {
   };
 
   _this.destroy = Util.compose(function () {
+    if (_this ===  null) {
+      return; // already destroyed
+    }
+
     if (_latitude) {
       _latitude.removeEventListener('change', _onInputChange, _this);
     }

--- a/src/htdocs/js/input/Location.js
+++ b/src/htdocs/js/input/Location.js
@@ -55,7 +55,12 @@ var Location = function (params) {
     _this.model.on('change:location', _this.checkLocation);
     _this.model.on('change:edition', _this.checkLocation);
 
-    _this.render(); // Render initially to reflect model state
+    // Render initially to reflect model state
+    _this.render();
+
+    // Bindings are removed and readded, so the events above will not
+    // trigger when switching between analyses in the collection
+    _this.checkLocation();
   };
 
 

--- a/src/htdocs/js/input/Location.js
+++ b/src/htdocs/js/input/Location.js
@@ -218,6 +218,9 @@ var Location = function (params) {
       _usemap.removeEventListener('click', _onUseMapClick, _this);
     }
 
+    _this.model.off('change:location', _this.checkLocation);
+    _this.model.off('change:edition', _this.checkLocation);
+
     _errorMessage = null;
     _inputLatitude = null;
     _inputLongitude = null;


### PR DESCRIPTION
Deploy https://github.com/usgs/earthquake-hazard-tool/pull/175 and then close this PR.

This fixes the following issues:
 - Old event bindings were not being destroyed. This caused issues when trying to update inputs after switching between different analyses in the collection.
 - Switching between analyses in the AnalysisCollectionView was leaving partial error messages on the InputView