### PR TITLE
Fix error when switching between items in the AnalysisCollectionView

### DIFF
--- a/src/htdocs/js/deagg/DeaggOutputView.js
+++ b/src/htdocs/js/deagg/DeaggOutputView.js
@@ -83,6 +83,11 @@ var DeaggOutputView = function (params) {
 
     el = _this.el.querySelector('.deagg-output-mask');
 
+
+    if (!_this.model) {
+      return;
+    }
+
     // check if edition supports a deagg calculation
     isSupported = _dependencyFactory.isSupportedEdition(
         _this.model.get('edition'));


### PR DESCRIPTION
Deploy https://github.com/usgs/earthquake-hazard-tool/pull/175 and then close this PR.

Fixes issue where the model is empty when switching between analyses in the AnalysisCollectionView.

When a collection item is deselected _this.model is set to null, this was causing _createAlertEl() to throw an error.