### PR TITLE
Update print styles for new markup

### DIFF
--- a/src/htdocs/css/_Print.scss
+++ b/src/htdocs/css/_Print.scss
@@ -29,7 +29,7 @@
     font-size: 0.88em;
   }
 
-  .horizontal-scrolling > .contributing-sources {
+  .contributors-section > .contributing-sources {
     border-spacing: 0;
     width: 100%;
 


### PR DESCRIPTION
The markup changed, so the table overflowing horizontally when printing.